### PR TITLE
fix(cloudregistration):oci changed user email optional:CTEST-53972

### DIFF
--- a/templates/Resource_Manager_Template/outputs.tf
+++ b/templates/Resource_Manager_Template/outputs.tf
@@ -4,7 +4,7 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value = "v0.3.2"
+  value = "v0.3.3"
   description = "The version of CrowdStrike's OCI integration supported by this template."
 }
 

--- a/templates/Resource_Manager_Template/variables.tf
+++ b/templates/Resource_Manager_Template/variables.tf
@@ -20,6 +20,7 @@ variable "policy_name" {
 
 variable "user_email_address" {
     description = "Email address that will be associated with the IAM user created by this template. Most OCI Identity Domains have a setting that requires each IAM user to have a valid email. This can be any valid email address, even one that's already associated with another IAM user in the tenancy."
+    default = ""
 }
 
 variable "api_public_key" {


### PR DESCRIPTION
User email is optional when creating a stack/user
Updated the user email to be default. Tested it using the zip file.


To disable primary email requirement
https://docs.oracle.com/en-us/iaas/Content/Identity/defaultsettings/set-primary-email-user.htm
