### PR TITLE
Remove tflint init

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -41,8 +41,3 @@ jobs:
           pre-commit run --all-files
         env:
           SKIP: no-commit-to-branch
-
-      - name: Run TFLint
-        run: |
-          tflint --init
-          tflint --format=compact


### PR DESCRIPTION
Removed TFlint init, due to redundant as we dont need this check for the validation