### PR TITLE
Add permissions to ingest objectstorage buckets

### DIFF
--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -120,7 +120,8 @@ resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
     "Allow group ${var.group_name} to inspect groups in tenancy",
     "Allow group ${var.group_name} to inspect domains in tenancy",
     "Allow group ${var.group_name} to inspect orm-stacks in tenancy",
-    "Allow group ${var.group_name} to read instances in tenancy"
+    "Allow group ${var.group_name} to read instances in tenancy",
+    "Allow group ${var.group_name} to read buckets in tenancy"
   ]
 }
 
@@ -138,7 +139,8 @@ resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
     "Allow group 'Default'/'${var.group_name}' to inspect groups in tenancy",
     "Allow group 'Default'/'${var.group_name}' to inspect domains in tenancy",
     "Allow group 'Default'/'${var.group_name}' to inspect orm-stacks in tenancy",
-    "Allow group 'Default'/'${var.group_name}' to read instances in tenancy"
+    "Allow group 'Default'/'${var.group_name}' to read instances in tenancy",
+    "Allow group 'Default'/'${var.group_name}' to read buckets in tenancy"
   ]
 }
 

--- a/templates/Resource_Manager_Template/modules/iom/outputs.tf
+++ b/templates/Resource_Manager_Template/modules/iom/outputs.tf
@@ -4,6 +4,6 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value       = "v0.3.6"
+  value       = "v0.3.7"
   description = "The version of CrowdStrike's OCI integration supported by this template"
 }

--- a/templates/Resource_Manager_Template/outputs.tf
+++ b/templates/Resource_Manager_Template/outputs.tf
@@ -4,7 +4,7 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value       = "v0.3.6"
+  value       = "v0.3.7"
   description = "The version of CrowdStrike's OCI integration supported by this template."
 }
 


### PR DESCRIPTION
Add permissions to ingest objectstorage buckets.

Tested by manually creating a zip file and updating an existing stack and checking permissions are added as expected.