### PR TITLE
Add permissions for virtual-network-family and autonomous databases

### DIFF
--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -122,7 +122,8 @@ resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
     "Allow group ${var.group_name} to inspect orm-stacks in tenancy",
     "Allow group ${var.group_name} to read instances in tenancy",
     "Allow group ${var.group_name} to read buckets in tenancy",
-    "Allow group ${var.group_name} to read vcns in tenancy"
+    "Allow group ${var.group_name} to read virtual-network-family in tenancy",
+    "Allow group ${var.group_name} to inspect autonomous-database-family in tenancy"
   ]
 }
 
@@ -142,7 +143,8 @@ resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
     "Allow group 'Default'/'${var.group_name}' to inspect orm-stacks in tenancy",
     "Allow group 'Default'/'${var.group_name}' to read instances in tenancy",
     "Allow group 'Default'/'${var.group_name}' to read buckets in tenancy",
-    "Allow group 'Default'/'${var.group_name}' to read vcns in tenancy"
+    "Allow group 'Default'/'${var.group_name}' to read virtual-network-family in tenancy",
+    "Allow group 'Default'/'${var.group_name}' to inspect autonomous-database-family in tenancy"
   ]
 }
 

--- a/templates/Resource_Manager_Template/modules/iom/outputs.tf
+++ b/templates/Resource_Manager_Template/modules/iom/outputs.tf
@@ -4,6 +4,6 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value       = "v0.3.8"
+  value       = "v0.3.9"
   description = "The version of CrowdStrike's OCI integration supported by this template"
 }

--- a/templates/Resource_Manager_Template/outputs.tf
+++ b/templates/Resource_Manager_Template/outputs.tf
@@ -4,7 +4,7 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value       = "v0.3.8"
+  value       = "v0.3.9"
   description = "The version of CrowdStrike's OCI integration supported by this template."
 }
 


### PR DESCRIPTION
This PR includes the following changes:

- Add support for all virtual-network resources and autonomous databases
- Remove exiting VCN read permissions as those are included in the virtual-network-family policy group