### PR TITLE
fix(streams): fixing typo for stream-family permission

### DIFF
--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -139,7 +139,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
     "Allow group ${var.group_name} to read database-family in tenancy",
     "Allow group ${var.group_name} to read leaf-certificate-family in tenancy",
     "Allow group ${var.group_name} to read usage-budgets in tenancy",
-    "Allow group ${var.group_name} to read streams-family in tenancy",
+    "Allow group ${var.group_name} to read stream-family in tenancy",
     "Allow group ${var.group_name} to read waf-family in tenancy"
   ]
 }
@@ -177,7 +177,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
     "Allow group 'Default'/'${var.group_name}' to read database-family in tenancy",
     "Allow group 'Default'/'${var.group_name}' to read leaf-certificate-family in tenancy",
     "Allow group 'Default'/'${var.group_name}' to read usage-budgets in tenancy",
-    "Allow group 'Default'/'${var.group_name}' to read streams-family in tenancy",
+    "Allow group 'Default'/'${var.group_name}' to read stream-family in tenancy",
     "Allow group 'Default'/'${var.group_name}' to read waf-family in tenancy"
   ]
 }


### PR DESCRIPTION
Incorrect had a plural on this before.  Trying to remove without bumping the version number.

CSPG-61833