### PR TITLE
fix(oci): Add support for deploying the resource manager stack to a non-home region

### DIFF
--- a/templates/Resource_Manager_Template/main.tf
+++ b/templates/Resource_Manager_Template/main.tf
@@ -4,7 +4,7 @@
 # ---------------------------------------------------------------------------------------------------------------------
 
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
   required_providers {
     oci = {
       source  = "oracle/oci"

--- a/templates/Resource_Manager_Template/main.tf
+++ b/templates/Resource_Manager_Template/main.tf
@@ -13,14 +13,34 @@ terraform {
   }
 }
 
+# Determines the home region for the tenancy. Region subscriptions are global,
+# so this works correctly regardless of which region the stack is deployed in.
+data "oci_identity_region_subscriptions" "homeregion" {
+  tenancy_id = var.tenancy_ocid
+  filter {
+    name   = "is_home_region"
+    values = ["true"]
+  }
+}
+
+provider "oci" {
+  alias  = "home_region"
+  region = data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name
+}
+
 module "iom" {
   source = "./modules/iom"
 
+  providers = {
+    oci.home_region = oci.home_region
+  }
+
   tenancy_ocid         = var.tenancy_ocid
   expected_home_region = var.expected_home_region
-  user_name           = var.user_name
-  group_name          = var.group_name
-  policy_name         = var.policy_name
-  user_email_address  = var.user_email_address
-  api_public_key      = var.api_public_key
+  home_region_name     = data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name
+  user_name            = var.user_name
+  group_name           = var.group_name
+  policy_name          = var.policy_name
+  user_email_address   = var.user_email_address
+  api_public_key       = var.api_public_key
 }

--- a/templates/Resource_Manager_Template/main.tf
+++ b/templates/Resource_Manager_Template/main.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "~> 4.0"
+      version = "~> 8.0"
     }
   }
 }

--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     oci = {
       source                = "oracle/oci"
-      version               = "~> 4.0"
+      version               = "~> 8.0"
       configuration_aliases = [oci.home_region]
     }
   }

--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -15,8 +15,13 @@ terraform {
 
 
 locals {
-  email         = data.oci_identity_domains.default_domain.domains == null ? "" : var.user_email_address
-  idcs_endpoint = data.oci_identity_domains.default_domain.domains == null ? "" : data.oci_identity_domains.default_domain.domains[0].url
+  has_domain_url = (
+    data.oci_identity_domains.default_domain.domains != null &&
+    length(data.oci_identity_domains.default_domain.domains) > 0 &&
+    data.oci_identity_domains.default_domain.domains[0].url != ""
+  )
+  email         = local.has_domain_url ? var.user_email_address : ""
+  idcs_endpoint = local.has_domain_url ? data.oci_identity_domains.default_domain.domains[0].url : ""
 
   #The following locals are used to ensure that the provided OCI User API public key is formatted correctly
 
@@ -105,7 +110,7 @@ resource "oci_identity_user_group_membership" "fcs_user_into_group" {
 # This resource will get created if domain is not enabled
 resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
   provider       = oci.home_region
-  count          = data.oci_identity_domains.default_domain.domains == null ? 1 : 0
+  count          = local.has_domain_url ? 0 : 1
   name           = var.policy_name
   description    = "DO NOT TOUCH. This policy allows CrowdStrike Falcon Cloud Security to create an inventory of all supported resources in the tenancy"
   compartment_id = var.tenancy_ocid
@@ -154,7 +159,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
 # This resource will get created if domain enabled
 resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
   provider       = oci.home_region
-  count          = data.oci_identity_domains.default_domain.domains != null ? 1 : 0
+  count          = local.has_domain_url ? 1 : 0
   name           = var.policy_name
   description    = "DO NOT TOUCH. This policy allows CrowdStrike Falcon Cloud Security to create an inventory of all supported resources in the tenancy"
   compartment_id = var.tenancy_ocid
@@ -204,7 +209,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
 # This resource is only created if tenancy uses Identity Domains.
 resource "oci_identity_domains_api_key" "fcs_inventory_user_api_key" {
   provider      = oci.home_region
-  count         = data.oci_identity_domains.default_domain.domains != null ? 1 : 0
+  count         = local.has_domain_url ? 1 : 0
   idcs_endpoint = local.idcs_endpoint
   key           = local.reformatted_api_public_key
   schemas       = ["urn:ietf:params:scim:schemas:oracle:idcs:apikey"]
@@ -225,7 +230,7 @@ resource "oci_identity_domains_api_key" "fcs_inventory_user_api_key" {
 # This resource is only created if tenancy does not use Identity Domains.
 resource "oci_identity_api_key" "fcs_inventory_user_api_key" {
   provider  = oci.home_region
-  count     = data.oci_identity_domains.default_domain.domains == null ? 1 : 0
+  count     = local.has_domain_url ? 0 : 1
   key_value = local.reformatted_api_public_key
   user_id   = oci_identity_user.fcs_inventory_user.id
 }

--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -70,7 +70,6 @@ data "oci_identity_region_subscriptions" "homeregion" {
   }
 }
 
-
 # ---------------------------------------------------------------------------------------------------------------------
 #DEPLOY RESOURCES
 # ---------------------------------------------------------------------------------------------------------------------
@@ -78,6 +77,7 @@ data "oci_identity_region_subscriptions" "homeregion" {
 
 # Creates new IAM user that will be used by Falcon Cloud Security to access tenancy
 resource "oci_identity_user" "fcs_inventory_user" {
+  provider       = oci.home_region
   compartment_id = var.tenancy_ocid
   name           = var.user_name
   description    = "DO NOT TOUCH. Service account used by CrowdStrike to inventory resources in tenancy"
@@ -95,6 +95,7 @@ resource "oci_identity_user" "fcs_inventory_user" {
 
 # Creates group to house the IAM user defined by "fcs_inventory_user"
 resource "oci_identity_group" "fcs_inventory_group" {
+  provider       = oci.home_region
   compartment_id = var.tenancy_ocid
   name           = var.group_name
   description    = "DO NOT TOUCH. Group for CrowdStrike Falcon Cloud Security (FCS) service account. Used by FCS to generate inventory of all supported resources in the tenancy"
@@ -102,6 +103,7 @@ resource "oci_identity_group" "fcs_inventory_group" {
 
 # Add "fcs_inventory_user" to "fcs_inventory_group"
 resource "oci_identity_user_group_membership" "fcs_user_into_group" {
+  provider = oci.home_region
   group_id = oci_identity_group.fcs_inventory_group.id
   user_id  = oci_identity_user.fcs_inventory_user.id
 }
@@ -109,6 +111,7 @@ resource "oci_identity_user_group_membership" "fcs_user_into_group" {
 # Creates new policy with permissions Falcon Cloud Security needs to monitor supported resources in the tenancy. Policy's permissions get applied to users in "fcs_inventory_group"
 # This resource will get created if domain is not enabled
 resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
+  provider       = oci.home_region
   count          = data.oci_identity_domains.default_domain.domains == null ? 1 : 0
   name           = var.policy_name
   description    = "DO NOT TOUCH. This policy allows CrowdStrike Falcon Cloud Security to create an inventory of all supported resources in the tenancy"
@@ -157,6 +160,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_without_domains" {
 # Creates new policy with permissions Falcon Cloud Security needs to monitor supported resources in the tenancy. Policy's permissions get applied to users in "fcs_inventory_group"
 # This resource will get created if domain enabled
 resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
+  provider       = oci.home_region
   count          = data.oci_identity_domains.default_domain.domains != null ? 1 : 0
   name           = var.policy_name
   description    = "DO NOT TOUCH. This policy allows CrowdStrike Falcon Cloud Security to create an inventory of all supported resources in the tenancy"
@@ -206,6 +210,7 @@ resource "oci_identity_policy" "fcs_inventory_policy_with_domains" {
 # Associates the public key portion of an API key with the IAM user defined by "fcs_inventory_user". Falcon Cloud Security will use this API key to authenticate into tenancy as the associated IAM user.
 # This resource is only created if tenancy uses Identity Domains.
 resource "oci_identity_domains_api_key" "fcs_inventory_user_api_key" {
+  provider      = oci.home_region
   count         = data.oci_identity_domains.default_domain.domains != null ? 1 : 0
   idcs_endpoint = local.idcs_endpoint
   key           = local.reformatted_api_public_key
@@ -226,6 +231,7 @@ resource "oci_identity_domains_api_key" "fcs_inventory_user_api_key" {
 # Associates the public key portion of an API key with the IAM user defined by "fcs_inventory_user". Falcon Cloud Security will use this API key to authenticate into tenancy as the associated IAM user.
 # This resource is only created if tenancy does not use Identity Domains.
 resource "oci_identity_api_key" "fcs_inventory_user_api_key" {
+  provider  = oci.home_region
   count     = data.oci_identity_domains.default_domain.domains == null ? 1 : 0
   key_value = local.reformatted_api_public_key
   user_id   = oci_identity_user.fcs_inventory_user.id

--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -2,8 +2,9 @@ terraform {
   required_version = ">= 1.2.0"
   required_providers {
     oci = {
-      source  = "oracle/oci"
-      version = "~> 4.0"
+      source                = "oracle/oci"
+      version               = "~> 4.0"
+      configuration_aliases = [oci.home_region]
     }
   }
 }
@@ -57,17 +58,9 @@ locals {
 
 # This will see if a the Default Identity Domain exists in the tenancy, to determine if tenancy uses Identity Domains or not (the resources that get deployed change depending on if a tenancy is using Identity Domains and data from the default domain is needed to configure some of the resources).
 data "oci_identity_domains" "default_domain" {
+  provider       = oci.home_region
   compartment_id = var.tenancy_ocid
   display_name   = "Default"
-}
-
-# Determines the home region for the Tenancy where this template is being deployed
-data "oci_identity_region_subscriptions" "homeregion" {
-  tenancy_id = var.tenancy_ocid
-  filter {
-    name   = "is_home_region"
-    values = ["true"]
-  }
 }
 
 # ---------------------------------------------------------------------------------------------------------------------
@@ -86,8 +79,8 @@ resource "oci_identity_user" "fcs_inventory_user" {
   # Checks that the tenancy's home region matches the value that was provided in the first step of the Falcon Cloud Security registration wizard
   lifecycle {
     precondition {
-      condition     = var.expected_home_region == data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name
-      error_message = "This tenancy has been configured in Falcon Cloud Security with a home region of ${var.expected_home_region}. It appears that the actual home region is ${data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name}. To fix this:\n1. Delete this stack in OCI Resource Manager. \n2. Go to the Falcon Cloud Security console and open the registration wizard for this tenancy.\n3. Go to Step 1 in the wizard and change the Home Region dropdown from ${var.expected_home_region} to ${data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name}.\n4. Download the updated template.\n5. Return to OCI Resource Manager and run the new template."
+      condition     = var.expected_home_region == var.home_region_name
+      error_message = "This tenancy has been configured in Falcon Cloud Security with a home region of ${var.expected_home_region}. It appears that the actual home region is ${var.home_region_name}. To fix this:\n1. Delete this stack in OCI Resource Manager. \n2. Go to the Falcon Cloud Security console and open the registration wizard for this tenancy.\n3. Go to Step 1 in the wizard and change the Home Region dropdown from ${var.expected_home_region} to ${var.home_region_name}.\n4. Download the updated template.\n5. Return to OCI Resource Manager and run the new template."
     }
   }
 }

--- a/templates/Resource_Manager_Template/modules/iom/main.tf
+++ b/templates/Resource_Manager_Template/modules/iom/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 1.2.0"
+  required_version = ">= 1.5.0"
   required_providers {
     oci = {
       source                = "oracle/oci"

--- a/templates/Resource_Manager_Template/modules/iom/provider.tf
+++ b/templates/Resource_Manager_Template/modules/iom/provider.tf
@@ -1,0 +1,7 @@
+# Providers
+
+# OCI Provider set to home region
+provider "oci" {
+  alias  = "home_region"
+  region = data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name
+}

--- a/templates/Resource_Manager_Template/modules/iom/provider.tf
+++ b/templates/Resource_Manager_Template/modules/iom/provider.tf
@@ -1,7 +1,0 @@
-# Providers
-
-# OCI Provider set to home region
-provider "oci" {
-  alias  = "home_region"
-  region = data.oci_identity_region_subscriptions.homeregion.region_subscriptions[0].region_name
-}

--- a/templates/Resource_Manager_Template/modules/iom/variables.tf
+++ b/templates/Resource_Manager_Template/modules/iom/variables.tf
@@ -8,6 +8,11 @@ variable "expected_home_region" {
   description = "The Home Region that was specified when registering this OCI tenancy in the Falcon Cloud Security registration wizard. The value entered in the wizard must match the actual Home Region for the tenancy."
 }
 
+variable "home_region_name" {
+  type        = string
+  description = "The actual home region name for the tenancy, as determined by the region subscriptions data source."
+}
+
 variable "user_name" {
   type        = string
   description = "Friendly name for the OCI IAM user created when this template gets applied."

--- a/templates/Resource_Manager_Template/outputs.tf
+++ b/templates/Resource_Manager_Template/outputs.tf
@@ -4,7 +4,7 @@ output "user_ocid" {
 }
 
 output "template_version" {
-  value       = "v0.3.25"
+  value       = "v0.3.26"
   description = "The version of CrowdStrike's OCI integration supported by this template."
 }
 


### PR DESCRIPTION
## Summary

When customers deploy the OCI Resource Manager stack, the `oci_identity_domains_api_key` resource fails with:

```
Error: [ERROR] IdcsEndpointHelper: idcs_endpoint missing for resource
```

This happens in two scenarios:

1. **Non-home region deployment**: The `oci_identity_domains` data source returns a domain object with an empty IDCS endpoint URL when queried from a region other than the tenancy's home region.
2. **Lightweight Identity Domains**: Tenancies using OCI's "Lightweight" domain type have a domain object but no domain URL at all — even when queried from the home region.

Both cases result in `idcs_endpoint = ""` being passed to `oci_identity_domains_api_key`, which requires a non-empty value.

## Design Decisions

**Cross-region support**: Rather than failing fast when the ORM stack region doesn't match the home region, we deploy successfully from any region. Customers shouldn't need to know which region to create their stack in. The `expected_home_region` precondition is preserved as it catches a different problem (FCS backend misconfiguration).

**Lightweight domain fallback**: Tenancies with Lightweight domains fall through to the `oci_identity_api_key` resource (the non-domains path), which doesn't require an IDCS endpoint. A single `local.has_domain_url` boolean gates all domain-dependent resources, checking that the domain exists *and* has a usable URL.

**OCI provider upgrade (`~> 4.0` → `~> 8.0`)**: The integration surface is limited to basic IAM primitives (users, groups, policies, API keys) which have maintained schema compatibility across majors. Pinning to `~> 8.0` gives customers the latest provider features and fixes while still requiring an explicit bump for the next major. Existing deployed stacks are unaffected — ORM stacks are self-contained and only resolve provider versions from the template they were given.

## Changes

- **Root module (`main.tf`)**: Added `oci_identity_region_subscriptions` data source and `oci.home_region` provider alias. The provider is passed to the child module via `providers = {}`. Region subscriptions are a global tenancy-level lookup, so this works from any region.
- **Child module (`modules/iom/main.tf`)**:
  - Declared `configuration_aliases = [oci.home_region]` in `required_providers`. All identity resources and the `oci_identity_domains` data source now use `provider = oci.home_region`.
  - Introduced `local.has_domain_url` — checks that the domain is non-null, the list is non-empty, and `domains[0].url` is non-empty. Replaced all four `domains == null` / `domains != null` count conditions with this local.
  - Removed the `homeregion` data source (now lives in root). Updated precondition to use `var.home_region_name`.
- **Deleted `modules/iom/provider.tf`**: Defining a provider inside a child module with a dependency on a data source in the same module is a Terraform anti-pattern that causes `terraform destroy` failures.
- **Child module (`modules/iom/variables.tf`)**: Added `home_region_name` variable.
- **OCI provider constraint updated to `~> 8.0`** in both root and child modules.
- **Terraform minimum version bumped to `>= 1.5.0`** (OCI Resource Manager is deprecating < 1.5.x).
- **Template version bumped to `v0.3.26`**.

## Test Plan

- [x] `terraform plan` succeeds when ORM stack region matches home region
- [x] `terraform plan` succeeds when ORM stack region differs from home region
- [x] `terraform destroy` works cleanly from a non-home region
- [x] Precondition still fails when `expected_home_region` doesn't match actual home region
- [x] Tenancy with Lightweight Identity Domain falls through to `oci_identity_api_key` (non-domains path)
- [x] Tenancy with full Identity Domain still uses `oci_identity_domains_api_key`
- [x] Existing registrations are upgrade-able using the newest TF version and OCI Provider
- [x] OCI provider resolves to 8.x without errors

## References

- SUPPORT-52301 — Customer report of Lightweight domain failure
- CSPG-89764 — Non-home region support
- CSPG-94472 — Lightweight domain fix